### PR TITLE
Add Fluidsynth support

### DIFF
--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -19,8 +19,14 @@ finish-args:
   - --filesystem=home
 
 modules:
-
-  # - "shared-modules/linux-audio/fluidsynth2.json"
+  - name: fluidsynth
+    buildsystem: cmake
+    config-opts:
+      - -DLIB_INSTALL_DIR=${FLATPAK_DEST}/lib
+    sources:
+      - type: git
+        url: https://github.com/FluidSynth/fluidsynth
+        tag: v2.1.5
 
   - name: dosbox-staging
 
@@ -29,8 +35,6 @@ modules:
         url: https://github.com/dosbox-staging/dosbox-staging/archive/v0.76.0.tar.gz
         sha256: 7df53c22f7ce78c70afb60b26b06742b90193b56c510219979bf12e0bb2dc6c7
 
-    config-opts:
-      - --disable-fluidsynth
 
     make-args:
       - V=1

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -31,16 +31,12 @@ modules:
         tag: v2.1.5
 
   - name: dosbox-staging
-
     sources:
       - type: archive
         url: https://github.com/dosbox-staging/dosbox-staging/archive/v0.76.0.tar.gz
         sha256: 7df53c22f7ce78c70afb60b26b06742b90193b56c510219979bf12e0bb2dc6c7
-
-
     make-args:
       - V=1
-
     post-install:
       # icons
       - make -C contrib/icons hicolor

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -18,6 +18,8 @@ finish-args:
   - --socket=pulseaudio
   - --filesystem=home
 
+cleanup:
+  - /include
 modules:
   - name: fluidsynth
     buildsystem: cmake

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -20,6 +20,8 @@ finish-args:
 
 cleanup:
   - /include
+  - /lib/pkgconfig
+  - /share/man
 modules:
   - name: fluidsynth
     buildsystem: cmake


### PR DESCRIPTION
If I'm interpreting the intent of this comment correctly, there's interest in adding fluidsynth support:

https://github.com/flathub/io.github.dosbox-staging/blob/a5f814410b5f27680a24db991d5ef7a327147879/io.github.dosbox-staging.yml#L23

The configure script in dosbox-staging doesn't seem to be able to detect fluidsynth during the build process since it's only looking in `/app/lib/pkgconfig` when there's also `/app/lib64/pkgconfig` put in place by the [fluidsynth2 shared module](https://github.com/flathub/shared-modules/blob/master/linux-audio/fluidsynth2.json). You should be able to build with fluidsynth enabled using the submitted changes.