### PR TITLE
Upgrade to 0.80.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,17 @@ flatpak update
   with the override command. But note that this does not work for all directories
   as some (like ``/usr``) have special restrictions. For instance, to allow access
    to ``/run/media`` where USB devices are typically mounted, run the following command:
-    - ``flatpak override --filesystem=/run/media io.github.dosbox-staging``
+    - ``flatpak override --user --filesystem=/run/media io.github.dosbox-staging``
 - Likewise, there is no way to access system installed MIDI soundfonts under ``/usr``.
   If you want to use such soundfonts, copy them into your home directory and
   specify the location in your DOSBox-Staging config file.
-- The SDL2 libraries against which DOSBox-Staging is built are provided by flatpak. This build only supports PulseAudio and dummy sound options, and likewise only supports X11, Wayland and dummy video options.
-  - You will need a working PulseAudio (or PipeWire) setup on the host, or DOSBox-Staging will not start. If you don't care for audio, you can use the dummy SDL audio driver once you installed the flatpak by running:
-    - ``flatpak override --env=SDL_AUDIODRIVER=dummy io.github.dosbox-staging``
-  - You will need a working X11 or Wayland setup on the host. Running from a console will not work, as the SDL2 build does not have kms or directfb output enabled. If you run into problems with Wayland, you can force XWayland with ``flatpak override --env=SDL_VIDEODRIVER=x11 io.github.dosbox-staging``
+- You will need a working audio and video setup on the host or DOSBox-Staging will not start.
+  - For audio you will need a working PulseAudio or PipeWire setup on the host. If you don't care for audio, you can use the dummy SDL audio driver once you installed the flatpak by running:
+    - ``flatpak override --user --env=SDL_AUDIODRIVER=dummy io.github.dosbox-staging``
+  - Also currently SDL2 will not use PipeWire by default, to enable it run:
+    - ``flatpak override --user --env=SDL_AUDIODRIVER=pipewire --filesystem=xdg-run/pipewire-0:ro io.github.dosbox-staging``
+  - For video you will need a working X11 or Wayland setup on the host. Running from a console will not work, as the SDL2 build does not have kms or directfb output enabled. If you run into problems with Wayland, you can force XWayland with:
+    - ``flatpak override --user --nosocket=fallback-x11 --nosocket=wayland --socket=x11 --env=SDL_VIDEODRIVER=x11 io.github.dosbox-staging``
 
 Please [create an issue](https://github.com/flathub/io.github.dosbox-staging/issues/new)
 if you find any other limitations specific to flatpak that should be documented here.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ flatpak update
   - For audio you will need a working PulseAudio or PipeWire setup on the host. If you don't care for audio, you can use the dummy SDL audio driver once you installed the flatpak by running:
     - ``flatpak override --user --env=SDL_AUDIODRIVER=dummy io.github.dosbox-staging``
   - Also currently SDL2 will not use PipeWire by default, to enable it run:
-    - ``flatpak override --user --env=SDL_AUDIODRIVER=pipewire --filesystem=xdg-run/pipewire-0:ro io.github.dosbox-staging``
+    - ``flatpak override --user --env=SDL_AUDIODRIVER=pipewire io.github.dosbox-staging``
   - For video you will need a working X11 or Wayland setup on the host. Running from a console will not work, as the SDL2 build does not have kms or directfb output enabled. If you run into problems with Wayland, you can force XWayland with:
     - ``flatpak override --user --nosocket=fallback-x11 --nosocket=wayland --socket=x11 --env=SDL_VIDEODRIVER=x11 io.github.dosbox-staging``
 

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -26,6 +26,7 @@ finish-args:
 modules:
 
   # Build SDL2 with required modules
+  #  reevaluate if this is required on next runtime upgrade
   - libSDL2.yml
 
   # Build FluidSynth for General MIDI emulation

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -115,8 +115,8 @@ modules:
       - -Dsystem_libraries=speexdsp
     sources:
       - type: archive
-        url: https://github.com/dosbox-staging/dosbox-staging/archive/refs/tags/v0.79.1.tar.gz
-        sha256: 43f23fd0a5cff55e06a3ba2be8403f872ae47423f3bb4f823301eaae8a39ac2f
+        url: https://github.com/dosbox-staging/dosbox-staging/archive/refs/tags/v0.80.0.tar.gz
+        sha256: d4f6a4517402fba9bf81596a591e119062d26c7411c791eb0157cc6c89dfacdf
         x-checker-data:
           type: anitya
           project-id: 234902

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -22,6 +22,7 @@ finish-args:
   - --share=ipc           # necessary for x11
   - --socket=pulseaudio
   - --filesystem=home
+  - --filesystem=xdg-run/pipewire-0:ro
 
 modules:
 

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -25,25 +25,11 @@ finish-args:
 
 modules:
 
+  # Build SDL2 with required modules
+  - libSDL2.yml
+
   # Build FluidSynth for General MIDI emulation
   - shared-modules/linux-audio/fluidsynth2.json
-
-  # Build SDL2 with libdecor for Wayland support
-  - shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json
-  - name: SDL2_image
-    buildsystem: autotools
-    config-opts:
-      - --disable-static
-    cleanup:
-      - '*.la'
-    sources:
-      - type: archive
-        url: https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-2.6.2.tar.gz
-        sha256: 5d91ea72b449a161821ef51464d0767efb6fedf7a773f923c43e483dc137e362
-        x-checker-data:
-          type: anitya
-          project-id: 4781
-          url-template: https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-$version.tar.gz
 
   # Build iir1 DSP filter lib
   - name: iir1
@@ -87,23 +73,6 @@ modules:
           type: anitya
           project-id: 220368
           url-template: https://github.com/munt/munt/archive/libmt32emu_$version.tar.gz
-
-  # SDL2 Networking support
-  - name: SDL2_net
-    buildsystem: autotools
-    config-opts:
-      - --disable-static
-      - --disable-gui
-    cleanup:
-      - '*.la'
-    sources:
-      - type: archive
-        url: https://github.com/libsdl-org/SDL_net/archive/refs/tags/release-2.2.0.tar.gz
-        sha256: 08d741282c0c22b82ed134f09cd319803132289cae06fb47b5ada2752faf0493
-        x-checker-data:
-          type: anitya
-          project-id: 4783
-          url-template: https://github.com/libsdl-org/SDL_net/archive/refs/tags/release-$version.tar.gz
 
   # Build libslirp for TCP/IP networking
   - name: libslirp

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -30,6 +30,20 @@ modules:
 
   # Build SDL2 with libdecor for Wayland support
   - shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json
+  - name: SDL2_image
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+    cleanup:
+      - '*.la'
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-2.6.2.tar.gz
+        sha256: 5d91ea72b449a161821ef51464d0767efb6fedf7a773f923c43e483dc137e362
+        x-checker-data:
+          type: anitya
+          project-id: 4781
+          url-template: https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-$version.tar.gz
 
   # Build iir1 DSP filter lib
   - name: iir1

--- a/libSDL2.yml
+++ b/libSDL2.yml
@@ -1,0 +1,55 @@
+name: libSDL2
+modules:
+  # libdecor for CSD Wayland support
+  - shared-modules/libdecor/libdecor-0.1.1.json
+
+  # SDL2 main library
+  - name: SDL2
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --disable-gui
+    cleanup:
+      - '*.la'
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL/archive/refs/tags/release-2.26.1.tar.gz
+        sha256: 91d8d26fc45a27c215b70090b351fd30e36bfe44bdd940e5db13d5148058d226
+        x-checker-data:
+          type: anitya
+          project-id: 4779
+          url-template: https://github.com/libsdl-org/SDL/archive/refs/tags/release-$version.tar.gz
+
+  # SDL2 Image support
+  - name: SDL2_image
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --disable-gui
+    cleanup:
+      - '*.la'
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-2.6.2.tar.gz
+        sha256: 5d91ea72b449a161821ef51464d0767efb6fedf7a773f923c43e483dc137e362
+        x-checker-data:
+          type: anitya
+          project-id: 4781
+          url-template: https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-$version.tar.gz
+
+  # SDL2 Networking support
+  - name: SDL2_net
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --disable-gui
+    cleanup:
+      - '*.la'
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_net/archive/refs/tags/release-2.2.0.tar.gz
+        sha256: 08d741282c0c22b82ed134f09cd319803132289cae06fb47b5ada2752faf0493
+        x-checker-data:
+          type: anitya
+          project-id: 4783
+          url-template: https://github.com/libsdl-org/SDL_net/archive/refs/tags/release-$version.tar.gz

--- a/libSDL2.yml
+++ b/libSDL2.yml
@@ -1,7 +1,21 @@
 name: libSDL2
 modules:
   # libdecor for CSD Wayland support
-  - shared-modules/libdecor/libdecor-0.1.1.json
+  - name: libdecor
+    buildsystem: meson
+    config-opts:
+      - -Ddemo=false
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/0.1.1/libdecor-0.1.1.tar.gz
+        sha256: 82adece5baeb6194292b0d1a91b4b3d10da41115f352a5e6c5844b20b88a0512
+        x-checker-data:
+          type: anitya
+          project-id: 312806
+          url-template: https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/$version/libdecor-$version.tar.gz
 
   # SDL2 main library
   - name: SDL2


### PR DESCRIPTION
To fix the current build with libdecor+libSDL2 updated it was only required to add also the SDL2_image library: d9fa15347112031eee241d7e1a78c923eb9916b9

I was starting having thoughts if it was really useful to use the `shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json` since with that, SDL2_image will have automatic updates but not the main SDL2 inside the shared-module.
So I decoupled the SDL2 from the shared module and enabled it to auto-update too.

And since now there are starting to have too many SDL modules, I moved all of them into a separated file containing:
- libdecor
- libSDL2
- libSDL2_image
- libSDL2_net

This should allow closing this PRs: #20, #21, #23
