### PR TITLE
0.81.0

### DIFF
--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -10,8 +10,6 @@ build_options:
   cflags: -O3
   cxxflags: -O3
 
-
-
 rename-desktop-file: dosbox-staging.desktop
 rename-appdata-file: dosbox-staging.metainfo.xml
 rename-icon: dosbox-staging

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -10,6 +10,8 @@ build_options:
   cflags: -O3
   cxxflags: -O3
 
+
+
 rename-desktop-file: dosbox-staging.desktop
 rename-appdata-file: dosbox-staging.metainfo.xml
 rename-icon: dosbox-staging
@@ -23,6 +25,9 @@ finish-args:
   - --socket=pulseaudio
   - --filesystem=home
   - --filesystem=xdg-run/pipewire-0:ro
+
+cleanup-commands:
+  - 'find /app -name 1024x1024 -exec rm -rf {} +'
 
 modules:
 
@@ -93,10 +98,13 @@ modules:
     config-opts:
       - -Dbuildtype=release
       - -Ddefault_library=shared
+    cleanup:
+      #- 'dosbox-staging.png'
+      - '/app/share/icons/hicolor/1024x1024/apps/*.png'
     sources:
       - type: archive
-        url: https://github.com/dosbox-staging/dosbox-staging/archive/refs/tags/v0.80.1.tar.gz
-        sha256: 2ca69e65e6c181197b63388c60487a3bcea804232a28c44c37704e70d49a0392
+        url: https://github.com/dosbox-staging/dosbox-staging/archive/refs/tags/v0.81.0.tar.gz
+        sha256: 9b133dbf2fe8410bb475267a8f26844d56b9025079783ec6a4574841888ae600
         x-checker-data:
           type: anitya
           project-id: 234902

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -96,9 +96,6 @@ modules:
     config-opts:
       - -Dbuildtype=release
       - -Ddefault_library=shared
-    cleanup:
-      #- 'dosbox-staging.png'
-      - '/app/share/icons/hicolor/1024x1024/apps/*.png'
     sources:
       - type: archive
         url: https://github.com/dosbox-staging/dosbox-staging/archive/refs/tags/v0.81.0.tar.gz


### PR DESCRIPTION
Bump release to 0.81.0

Also add a cleanup command to remove the 1024x1024 icon which was causing the build to fail due to rather ridiculous flathub rules.