### PR TITLE
limit device access

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ flatpak update
     - ``flatpak override --user --env=SDL_AUDIODRIVER=pipewire io.github.dosbox-staging``
   - For video you will need a working X11 or Wayland setup on the host. Running from a console will not work, as the SDL2 build does not have kms or directfb output enabled. If you run into problems with Wayland, you can force XWayland with:
     - ``flatpak override --user --nosocket=fallback-x11 --nosocket=wayland --socket=x11 --env=SDL_VIDEODRIVER=x11 io.github.dosbox-staging``
+ - Local serial port cannot be used. This is due to flatpak restrictions, you need to set 
+   full flatpak device access to allow access to a local serial TTY (in addition your
+   user needs to have the right permissions to access the serial port, and the serial port
+   needs to implement all signals)
+ - By default this flatpak has 'network' access. This access can be removed, but will prevent the following use-cases:
+    - Novell IPX (emulated over TCP/IP)
+    - NE2000 adapter emulation for DOS or early Windows TCP/IP networking
+    - Serial port over UDP (for modem or nullmodem connections)
+
 
 Please [create an issue](https://github.com/flathub/io.github.dosbox-staging/issues/new)
 if you find any other limitations specific to flatpak that should be documented here.

--- a/io.github.dosbox-staging.yml
+++ b/io.github.dosbox-staging.yml
@@ -15,7 +15,8 @@ rename-appdata-file: dosbox-staging.metainfo.xml
 rename-icon: dosbox-staging
 
 finish-args:
-  - --device=all          # we need OpenGL and controller access
+  - --device=dri          # default output is OpenGL
+  - --device=input        # gamepad access
   - --share=network       # IPX, libslirp and serial port emulation over UDP
   - --socket=fallback-x11 # X11 output support
   - --socket=wayland      # Wayland output support


### PR DESCRIPTION
Limit device access to just DRI (for OpenGL) and input for game controllers.

This does limit any other /dev access, the only thing I can think of would be a local serial port though, which should be a pretty rare use-case nowadays.